### PR TITLE
Refactoring the classes in Storage folder to align with InternApply

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -22,8 +22,8 @@ import seedu.address.model.ReadOnlyInternApplyMemory;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.util.SampleDataUtil;
-import seedu.address.storage.AddressBookStorage;
-import seedu.address.storage.JsonAddressBookStorage;
+import seedu.address.storage.InternApplyStorage;
+import seedu.address.storage.JsonInternApplyStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.Storage;
 import seedu.address.storage.StorageManager;
@@ -56,8 +56,8 @@ public class MainApp extends Application {
 
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
-        AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getInternApplyMemoryFilePath());
-        storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        InternApplyStorage internApplyStorage = new JsonInternApplyStorage(userPrefs.getInternApplyMemoryFilePath());
+        storage = new StorageManager(internApplyStorage, userPrefsStorage);
 
         initLogging(config);
 
@@ -77,7 +77,7 @@ public class MainApp extends Application {
         Optional<ReadOnlyInternApplyMemory> addressBookOptional;
         ReadOnlyInternApplyMemory initialData;
         try {
-            addressBookOptional = storage.readAddressBook();
+            addressBookOptional = storage.readInternApplyMemory();
             if (!addressBookOptional.isPresent()) {
                 logger.info("Data file not found. Will be starting with a sample AddressBook");
             }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -46,7 +46,7 @@ public class LogicManager implements Logic {
         commandResult = command.execute(model);
 
         try {
-            storage.saveAddressBook(model.getInternApplyMemory());
+            storage.saveInternApply(model.getInternApplyMemory());
         } catch (IOException ioe) {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }

--- a/src/main/java/seedu/address/storage/InternApplyStorage.java
+++ b/src/main/java/seedu/address/storage/InternApplyStorage.java
@@ -11,36 +11,36 @@ import seedu.address.model.ReadOnlyInternApplyMemory;
 /**
  * Represents a storage for {@link InternApplyMemory}.
  */
-public interface AddressBookStorage {
+public interface InternApplyStorage {
 
     /**
      * Returns the file path of the data file.
      */
-    Path getAddressBookFilePath();
+    Path getInternApplyFilePath();
 
     /**
-     * Returns AddressBook data as a {@link ReadOnlyInternApplyMemory}.
+     * Returns InternApply data as a {@link ReadOnlyInternApplyMemory}.
      *   Returns {@code Optional.empty()} if storage file is not found.
      * @throws DataConversionException if the data in storage is not in the expected format.
      * @throws IOException if there was any problem when reading from the storage.
      */
-    Optional<ReadOnlyInternApplyMemory> readAddressBook() throws DataConversionException, IOException;
+    Optional<ReadOnlyInternApplyMemory> readInternApplyMemory() throws DataConversionException, IOException;
 
     /**
-     * @see #getAddressBookFilePath()
+     * @see #getInternApplyFilePath()
      */
-    Optional<ReadOnlyInternApplyMemory> readAddressBook(Path filePath) throws DataConversionException, IOException;
+    Optional<ReadOnlyInternApplyMemory> readInternApplyMemory(Path filePath) throws DataConversionException, IOException;
 
     /**
      * Saves the given {@link ReadOnlyInternApplyMemory} to the storage.
-     * @param addressBook cannot be null.
+     * @param internApplyMemory cannot be null.
      * @throws IOException if there was any problem writing to the file.
      */
-    void saveAddressBook(ReadOnlyInternApplyMemory addressBook) throws IOException;
+    void saveInternApply(ReadOnlyInternApplyMemory internApplyMemory) throws IOException;
 
     /**
-     * @see #saveAddressBook(ReadOnlyInternApplyMemory)
+     * @see #saveInternApply(ReadOnlyInternApplyMemory)
      */
-    void saveAddressBook(ReadOnlyInternApplyMemory addressBook, Path filePath) throws IOException;
+    void saveInternApply(ReadOnlyInternApplyMemory internApplyMemory, Path filePath) throws IOException;
 
 }

--- a/src/main/java/seedu/address/storage/InternApplyStorage.java
+++ b/src/main/java/seedu/address/storage/InternApplyStorage.java
@@ -29,7 +29,8 @@ public interface InternApplyStorage {
     /**
      * @see #getInternApplyFilePath()
      */
-    Optional<ReadOnlyInternApplyMemory> readInternApplyMemory(Path filePath) throws DataConversionException, IOException;
+    Optional<ReadOnlyInternApplyMemory> readInternApplyMemory(Path filePath)
+            throws DataConversionException, IOException;
 
     /**
      * Saves the given {@link ReadOnlyInternApplyMemory} to the storage.

--- a/src/main/java/seedu/address/storage/JsonAdaptedApplication.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedApplication.java
@@ -20,9 +20,9 @@ import seedu.address.model.tag.Tag;
 /**
  * Jackson-friendly version of {@link Application}.
  */
-class JsonAdaptedPerson {
+class JsonAdaptedApplication {
 
-    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Application's %s field is missing!";
 
     private final String name;
     private final String phone;
@@ -31,12 +31,12 @@ class JsonAdaptedPerson {
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonAdaptedPerson} with the given person details.
+     * Constructs a {@code JsonAdaptedApplication} with the given application details.
      */
     @JsonCreator
-    public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-            @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+    public JsonAdaptedApplication(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
+                                  @JsonProperty("email") String email, @JsonProperty("address") String address,
+                                  @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -47,9 +47,9 @@ class JsonAdaptedPerson {
     }
 
     /**
-     * Converts a given {@code Person} into this class for Jackson use.
+     * Converts a given {@code Application} into this class for Jackson use.
      */
-    public JsonAdaptedPerson(Application source) {
+    public JsonAdaptedApplication(Application source) {
         name = source.getName().fullName;
         phone = source.getPhone().value;
         email = source.getEmail().value;
@@ -60,14 +60,14 @@ class JsonAdaptedPerson {
     }
 
     /**
-     * Converts this Jackson-friendly adapted person object into the model's {@code Person} object.
+     * Converts this Jackson-friendly adapted application object into the model's {@code Application} object.
      *
-     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     * @throws IllegalValueException if there were any data constraints violated in the adapted application.
      */
     public Application toModelType() throws IllegalValueException {
-        final List<Tag> personTags = new ArrayList<>();
+        final List<Tag> applicationTags = new ArrayList<>();
         for (JsonAdaptedTag tag : tagged) {
-            personTags.add(tag.toModelType());
+            applicationTags.add(tag.toModelType());
         }
 
         if (name == null) {
@@ -102,7 +102,7 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
-        final Set<Tag> modelTags = new HashSet<>(personTags);
+        final Set<Tag> modelTags = new HashSet<>(applicationTags);
         return new Application(modelName, modelPhone, modelEmail, modelAddress, modelTags);
     }
 

--- a/src/main/java/seedu/address/storage/JsonInternApplyStorage.java
+++ b/src/main/java/seedu/address/storage/JsonInternApplyStorage.java
@@ -15,7 +15,7 @@ import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.ReadOnlyInternApplyMemory;
 
 /**
- * A class to access AddressBook data stored as a json file on the hard disk.
+ * A class to access InternApply data stored as a json file on the hard disk.
  */
 public class JsonInternApplyStorage implements InternApplyStorage {
 
@@ -45,14 +45,14 @@ public class JsonInternApplyStorage implements InternApplyStorage {
     public Optional<ReadOnlyInternApplyMemory> readInternApplyMemory(Path filePath) throws DataConversionException {
         requireNonNull(filePath);
 
-        Optional<JsonSerializableAddressBook> jsonAddressBook = JsonUtil.readJsonFile(
+        Optional<JsonSerializableAddressBook> jsonInternApply = JsonUtil.readJsonFile(
                 filePath, JsonSerializableAddressBook.class);
-        if (!jsonAddressBook.isPresent()) {
+        if (!jsonInternApply.isPresent()) {
             return Optional.empty();
         }
 
         try {
-            return Optional.of(jsonAddressBook.get().toModelType());
+            return Optional.of(jsonInternApply.get().toModelType());
         } catch (IllegalValueException ive) {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataConversionException(ive);

--- a/src/main/java/seedu/address/storage/JsonInternApplyStorage.java
+++ b/src/main/java/seedu/address/storage/JsonInternApplyStorage.java
@@ -17,32 +17,32 @@ import seedu.address.model.ReadOnlyInternApplyMemory;
 /**
  * A class to access AddressBook data stored as a json file on the hard disk.
  */
-public class JsonAddressBookStorage implements AddressBookStorage {
+public class JsonInternApplyStorage implements InternApplyStorage {
 
-    private static final Logger logger = LogsCenter.getLogger(JsonAddressBookStorage.class);
+    private static final Logger logger = LogsCenter.getLogger(JsonInternApplyStorage.class);
 
     private Path filePath;
 
-    public JsonAddressBookStorage(Path filePath) {
+    public JsonInternApplyStorage(Path filePath) {
         this.filePath = filePath;
     }
 
-    public Path getAddressBookFilePath() {
+    public Path getInternApplyFilePath() {
         return filePath;
     }
 
     @Override
-    public Optional<ReadOnlyInternApplyMemory> readAddressBook() throws DataConversionException {
-        return readAddressBook(filePath);
+    public Optional<ReadOnlyInternApplyMemory> readInternApplyMemory() throws DataConversionException {
+        return readInternApplyMemory(filePath);
     }
 
     /**
-     * Similar to {@link #readAddressBook()}.
+     * Similar to {@link #readInternApplyMemory()}.
      *
      * @param filePath location of the data. Cannot be null.
      * @throws DataConversionException if the file is not in the correct format.
      */
-    public Optional<ReadOnlyInternApplyMemory> readAddressBook(Path filePath) throws DataConversionException {
+    public Optional<ReadOnlyInternApplyMemory> readInternApplyMemory(Path filePath) throws DataConversionException {
         requireNonNull(filePath);
 
         Optional<JsonSerializableAddressBook> jsonAddressBook = JsonUtil.readJsonFile(
@@ -60,21 +60,21 @@ public class JsonAddressBookStorage implements AddressBookStorage {
     }
 
     @Override
-    public void saveAddressBook(ReadOnlyInternApplyMemory addressBook) throws IOException {
-        saveAddressBook(addressBook, filePath);
+    public void saveInternApply(ReadOnlyInternApplyMemory internApplyMemory) throws IOException {
+        saveInternApply(internApplyMemory, filePath);
     }
 
     /**
-     * Similar to {@link #saveAddressBook(ReadOnlyInternApplyMemory)}.
+     * Similar to {@link #saveInternApply(ReadOnlyInternApplyMemory)}.
      *
      * @param filePath location of the data. Cannot be null.
      */
-    public void saveAddressBook(ReadOnlyInternApplyMemory addressBook, Path filePath) throws IOException {
-        requireNonNull(addressBook);
+    public void saveInternApply(ReadOnlyInternApplyMemory internApplyMemory, Path filePath) throws IOException {
+        requireNonNull(internApplyMemory);
         requireNonNull(filePath);
 
         FileUtil.createIfMissing(filePath);
-        JsonUtil.saveJsonFile(new JsonSerializableAddressBook(addressBook), filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableAddressBook(internApplyMemory), filePath);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonInternApplyStorage.java
+++ b/src/main/java/seedu/address/storage/JsonInternApplyStorage.java
@@ -45,8 +45,8 @@ public class JsonInternApplyStorage implements InternApplyStorage {
     public Optional<ReadOnlyInternApplyMemory> readInternApplyMemory(Path filePath) throws DataConversionException {
         requireNonNull(filePath);
 
-        Optional<JsonSerializableAddressBook> jsonInternApply = JsonUtil.readJsonFile(
-                filePath, JsonSerializableAddressBook.class);
+        Optional<JsonSerializableInternApply> jsonInternApply = JsonUtil.readJsonFile(
+                filePath, JsonSerializableInternApply.class);
         if (!jsonInternApply.isPresent()) {
             return Optional.empty();
         }
@@ -74,7 +74,7 @@ public class JsonInternApplyStorage implements InternApplyStorage {
         requireNonNull(filePath);
 
         FileUtil.createIfMissing(filePath);
-        JsonUtil.saveJsonFile(new JsonSerializableAddressBook(internApplyMemory), filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableInternApply(internApplyMemory), filePath);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -21,13 +21,13 @@ class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
 
-    private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedApplication> persons = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedApplication> persons) {
         this.persons.addAll(persons);
     }
 
@@ -37,7 +37,7 @@ class JsonSerializableAddressBook {
      * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
      */
     public JsonSerializableAddressBook(ReadOnlyInternApplyMemory source) {
-        persons.addAll(source.getApplicationList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        persons.addAll(source.getApplicationList().stream().map(JsonAdaptedApplication::new).collect(Collectors.toList()));
     }
 
     /**
@@ -47,8 +47,8 @@ class JsonSerializableAddressBook {
      */
     public InternApplyMemory toModelType() throws IllegalValueException {
         InternApplyMemory addressBook = new InternApplyMemory();
-        for (JsonAdaptedPerson jsonAdaptedPerson : persons) {
-            Application application = jsonAdaptedPerson.toModelType();
+        for (JsonAdaptedApplication jsonAdaptedApplication : persons) {
+            Application application = jsonAdaptedApplication.toModelType();
             if (addressBook.hasApplication(application)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }

--- a/src/main/java/seedu/address/storage/JsonSerializableInternApply.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableInternApply.java
@@ -14,47 +14,47 @@ import seedu.address.model.ReadOnlyInternApplyMemory;
 import seedu.address.model.application.Application;
 
 /**
- * An Immutable AddressBook that is serializable to JSON format.
+ * An Immutable InternApply that is serializable to JSON format.
  */
-@JsonRootName(value = "addressbook")
-class JsonSerializableAddressBook {
+@JsonRootName(value = "internapply")
+class JsonSerializableInternApply {
 
-    public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Applications list contains duplicate application(s).";
 
     private final List<JsonAdaptedApplication> persons = new ArrayList<>();
 
     /**
-     * Constructs a {@code JsonSerializableAddressBook} with the given persons.
+     * Constructs a {@code JsonSerializableInternApply} with the given applications.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedApplication> persons) {
-        this.persons.addAll(persons);
+    public JsonSerializableInternApply(@JsonProperty("persons") List<JsonAdaptedApplication> applications) {
+        this.persons.addAll(applications);
     }
 
     /**
-     * Converts a given {@code ReadOnlyAddressBook} into this class for Jackson use.
+     * Converts a given {@code ReadOnlyInternApplyMemory} into this class for Jackson use.
      *
-     * @param source future changes to this will not affect the created {@code JsonSerializableAddressBook}.
+     * @param source future changes to this will not affect the created {@code JsonSerializableInternApply}.
      */
-    public JsonSerializableAddressBook(ReadOnlyInternApplyMemory source) {
+    public JsonSerializableInternApply(ReadOnlyInternApplyMemory source) {
         persons.addAll(source.getApplicationList().stream().map(JsonAdaptedApplication::new).collect(Collectors.toList()));
     }
 
     /**
-     * Converts this address book into the model's {@code AddressBook} object.
+     * Converts this intern apply memory into the model's {@code InternApplyMemory} object.
      *
      * @throws IllegalValueException if there were any data constraints violated.
      */
     public InternApplyMemory toModelType() throws IllegalValueException {
-        InternApplyMemory addressBook = new InternApplyMemory();
+        InternApplyMemory internApplyMemory = new InternApplyMemory();
         for (JsonAdaptedApplication jsonAdaptedApplication : persons) {
             Application application = jsonAdaptedApplication.toModelType();
-            if (addressBook.hasApplication(application)) {
+            if (internApplyMemory.hasApplication(application)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_PERSON);
             }
-            addressBook.addApplication(application);
+            internApplyMemory.addApplication(application);
         }
-        return addressBook;
+        return internApplyMemory;
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableInternApply.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableInternApply.java
@@ -37,7 +37,8 @@ class JsonSerializableInternApply {
      * @param source future changes to this will not affect the created {@code JsonSerializableInternApply}.
      */
     public JsonSerializableInternApply(ReadOnlyInternApplyMemory source) {
-        persons.addAll(source.getApplicationList().stream().map(JsonAdaptedApplication::new).collect(Collectors.toList()));
+        persons.addAll(source.getApplicationList().stream().map(JsonAdaptedApplication::new)
+                .collect(Collectors.toList()));
     }
 
     /**

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -12,7 +12,7 @@ import seedu.address.model.UserPrefs;
 /**
  * API of the Storage component
  */
-public interface Storage extends AddressBookStorage, UserPrefsStorage {
+public interface Storage extends InternApplyStorage, UserPrefsStorage {
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;
@@ -21,12 +21,12 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
     void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException;
 
     @Override
-    Path getAddressBookFilePath();
+    Path getInternApplyFilePath();
 
     @Override
-    Optional<ReadOnlyInternApplyMemory> readAddressBook() throws DataConversionException, IOException;
+    Optional<ReadOnlyInternApplyMemory> readInternApplyMemory() throws DataConversionException, IOException;
 
     @Override
-    void saveAddressBook(ReadOnlyInternApplyMemory addressBook) throws IOException;
+    void saveInternApply(ReadOnlyInternApplyMemory internApplyMemory) throws IOException;
 
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -17,14 +17,14 @@ import seedu.address.model.UserPrefs;
 public class StorageManager implements Storage {
 
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
-    private AddressBookStorage addressBookStorage;
+    private InternApplyStorage internApplyStorage;
     private UserPrefsStorage userPrefsStorage;
 
     /**
      * Creates a {@code StorageManager} with the given {@code AddressBookStorage} and {@code UserPrefStorage}.
      */
-    public StorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage) {
-        this.addressBookStorage = addressBookStorage;
+    public StorageManager(InternApplyStorage internApplyStorage, UserPrefsStorage userPrefsStorage) {
+        this.internApplyStorage = internApplyStorage;
         this.userPrefsStorage = userPrefsStorage;
     }
 
@@ -49,31 +49,31 @@ public class StorageManager implements Storage {
     // ================ AddressBook methods ==============================
 
     @Override
-    public Path getAddressBookFilePath() {
-        return addressBookStorage.getAddressBookFilePath();
+    public Path getInternApplyFilePath() {
+        return internApplyStorage.getInternApplyFilePath();
     }
 
     @Override
-    public Optional<ReadOnlyInternApplyMemory> readAddressBook() throws DataConversionException, IOException {
-        return readAddressBook(addressBookStorage.getAddressBookFilePath());
+    public Optional<ReadOnlyInternApplyMemory> readInternApplyMemory() throws DataConversionException, IOException {
+        return readInternApplyMemory(internApplyStorage.getInternApplyFilePath());
     }
 
     @Override
-    public Optional<ReadOnlyInternApplyMemory> readAddressBook(Path filePath)
+    public Optional<ReadOnlyInternApplyMemory> readInternApplyMemory(Path filePath)
             throws DataConversionException, IOException {
         logger.fine("Attempting to read data from file: " + filePath);
-        return addressBookStorage.readAddressBook(filePath);
+        return internApplyStorage.readInternApplyMemory(filePath);
     }
 
     @Override
-    public void saveAddressBook(ReadOnlyInternApplyMemory addressBook) throws IOException {
-        saveAddressBook(addressBook, addressBookStorage.getAddressBookFilePath());
+    public void saveInternApply(ReadOnlyInternApplyMemory internApplyMemory) throws IOException {
+        saveInternApply(internApplyMemory, internApplyStorage.getInternApplyFilePath());
     }
 
     @Override
-    public void saveAddressBook(ReadOnlyInternApplyMemory addressBook, Path filePath) throws IOException {
+    public void saveInternApply(ReadOnlyInternApplyMemory internApplyMemory, Path filePath) throws IOException {
         logger.fine("Attempting to write to data file: " + filePath);
-        addressBookStorage.saveAddressBook(addressBook, filePath);
+        internApplyStorage.saveInternApply(internApplyMemory, filePath);
     }
 
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -12,7 +12,7 @@ import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
 
 /**
- * Manages storage of AddressBook data in local storage.
+ * Manages storage of InternApply data in local storage.
  */
 public class StorageManager implements Storage {
 
@@ -21,7 +21,7 @@ public class StorageManager implements Storage {
     private UserPrefsStorage userPrefsStorage;
 
     /**
-     * Creates a {@code StorageManager} with the given {@code AddressBookStorage} and {@code UserPrefStorage}.
+     * Creates a {@code StorageManager} with the given {@code InternApplyStorage} and {@code UserPrefStorage}.
      */
     public StorageManager(InternApplyStorage internApplyStorage, UserPrefsStorage userPrefsStorage) {
         this.internApplyStorage = internApplyStorage;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -27,7 +27,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyInternApplyMemory;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.application.Application;
-import seedu.address.storage.JsonAddressBookStorage;
+import seedu.address.storage.JsonInternApplyStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
 import seedu.address.testutil.PersonBuilder;
@@ -43,8 +43,8 @@ public class LogicManagerTest {
 
     @BeforeEach
     public void setUp() {
-        JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
+        JsonInternApplyStorage addressBookStorage =
+                new JsonInternApplyStorage(temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
@@ -71,8 +71,8 @@ public class LogicManagerTest {
     @Test
     public void execute_storageThrowsIoException_throwsCommandException() {
         // Setup LogicManager with JsonAddressBookIoExceptionThrowingStub
-        JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookIoExceptionThrowingStub(temporaryFolder.resolve("ioExceptionAddressBook.json"));
+        JsonInternApplyStorage addressBookStorage =
+                new JsonInternApplyIoExceptionThrowingStub(temporaryFolder.resolve("ioExceptionAddressBook.json"));
         JsonUserPrefsStorage userPrefsStorage =
                 new JsonUserPrefsStorage(temporaryFolder.resolve("ioExceptionUserPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
@@ -149,13 +149,13 @@ public class LogicManagerTest {
     /**
      * A stub class to throw an {@code IOException} when the save method is called.
      */
-    private static class JsonAddressBookIoExceptionThrowingStub extends JsonAddressBookStorage {
-        private JsonAddressBookIoExceptionThrowingStub(Path filePath) {
+    private static class JsonInternApplyIoExceptionThrowingStub extends JsonInternApplyStorage {
+        private JsonInternApplyIoExceptionThrowingStub(Path filePath) {
             super(filePath);
         }
 
         @Override
-        public void saveAddressBook(ReadOnlyInternApplyMemory addressBook, Path filePath) throws IOException {
+        public void saveInternApply(ReadOnlyInternApplyMemory internApplyMemory, Path filePath) throws IOException {
             throw DUMMY_IO_EXCEPTION;
         }
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedApplicationTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedApplicationTest.java
@@ -1,7 +1,7 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
+import static seedu.address.storage.JsonAdaptedApplication.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
@@ -34,66 +34,66 @@ public class JsonAdaptedApplicationTest {
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(BENSON);
+        JsonAdaptedApplication person = new JsonAdaptedApplication(BENSON);
         assertEquals(BENSON, person.toModelType());
     }
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person =
+                new JsonAdaptedApplication(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person = new JsonAdaptedApplication(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person =
+                new JsonAdaptedApplication(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person = new JsonAdaptedApplication(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person =
+                new JsonAdaptedApplication(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person = new JsonAdaptedApplication(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person =
+                new JsonAdaptedApplication(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedApplication person = new JsonAdaptedApplication(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -102,8 +102,8 @@ public class JsonAdaptedApplicationTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+        JsonAdaptedApplication person =
+                new JsonAdaptedApplication(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedApplicationTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedApplicationTest.java
@@ -48,7 +48,8 @@ public class JsonAdaptedApplicationTest {
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedApplication person = new JsonAdaptedApplication(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person =
+                new JsonAdaptedApplication(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -63,7 +64,8 @@ public class JsonAdaptedApplicationTest {
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedApplication person = new JsonAdaptedApplication(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person =
+                new JsonAdaptedApplication(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -78,7 +80,8 @@ public class JsonAdaptedApplicationTest {
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedApplication person = new JsonAdaptedApplication(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedApplication person =
+                new JsonAdaptedApplication(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -93,7 +96,8 @@ public class JsonAdaptedApplicationTest {
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedApplication person = new JsonAdaptedApplication(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedApplication person =
+                new JsonAdaptedApplication(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }

--- a/src/test/java/seedu/address/storage/JsonInternApplyStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonInternApplyStorageTest.java
@@ -19,7 +19,7 @@ import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.model.InternApplyMemory;
 import seedu.address.model.ReadOnlyInternApplyMemory;
 
-public class JsonAddressBookStorageTest {
+public class JsonInternApplyStorageTest {
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonAddressBookStorageTest");
 
     @TempDir
@@ -31,7 +31,7 @@ public class JsonAddressBookStorageTest {
     }
 
     private java.util.Optional<ReadOnlyInternApplyMemory> readAddressBook(String filePath) throws Exception {
-        return new JsonAddressBookStorage(Paths.get(filePath)).readAddressBook(addToTestDataPathIfNotNull(filePath));
+        return new JsonInternApplyStorage(Paths.get(filePath)).readInternApplyMemory(addToTestDataPathIfNotNull(filePath));
     }
 
     private Path addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {
@@ -64,24 +64,24 @@ public class JsonAddressBookStorageTest {
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
         Path filePath = testFolder.resolve("TempAddressBook.json");
         InternApplyMemory original = getTypicalAddressBook();
-        JsonAddressBookStorage jsonAddressBookStorage = new JsonAddressBookStorage(filePath);
+        JsonInternApplyStorage jsonAddressBookStorage = new JsonInternApplyStorage(filePath);
 
         // Save in new file and read back
-        jsonAddressBookStorage.saveAddressBook(original, filePath);
-        ReadOnlyInternApplyMemory readBack = jsonAddressBookStorage.readAddressBook(filePath).get();
+        jsonAddressBookStorage.saveInternApply(original, filePath);
+        ReadOnlyInternApplyMemory readBack = jsonAddressBookStorage.readInternApplyMemory(filePath).get();
         assertEquals(original, new InternApplyMemory(readBack));
 
         // Modify data, overwrite exiting file, and read back
         original.addApplication(HOON);
         original.removeApplication(ALICE);
-        jsonAddressBookStorage.saveAddressBook(original, filePath);
-        readBack = jsonAddressBookStorage.readAddressBook(filePath).get();
+        jsonAddressBookStorage.saveInternApply(original, filePath);
+        readBack = jsonAddressBookStorage.readInternApplyMemory(filePath).get();
         assertEquals(original, new InternApplyMemory(readBack));
 
         // Save and read without specifying file path
         original.addApplication(IDA);
-        jsonAddressBookStorage.saveAddressBook(original); // file path not specified
-        readBack = jsonAddressBookStorage.readAddressBook().get(); // file path not specified
+        jsonAddressBookStorage.saveInternApply(original); // file path not specified
+        readBack = jsonAddressBookStorage.readInternApplyMemory().get(); // file path not specified
         assertEquals(original, new InternApplyMemory(readBack));
 
     }
@@ -96,8 +96,8 @@ public class JsonAddressBookStorageTest {
      */
     private void saveAddressBook(ReadOnlyInternApplyMemory addressBook, String filePath) {
         try {
-            new JsonAddressBookStorage(Paths.get(filePath))
-                    .saveAddressBook(addressBook, addToTestDataPathIfNotNull(filePath));
+            new JsonInternApplyStorage(Paths.get(filePath))
+                    .saveInternApply(addressBook, addToTestDataPathIfNotNull(filePath));
         } catch (IOException ioe) {
             throw new AssertionError("There should not be an error writing to the file.", ioe);
         }

--- a/src/test/java/seedu/address/storage/JsonInternApplyStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonInternApplyStorageTest.java
@@ -31,7 +31,8 @@ public class JsonInternApplyStorageTest {
     }
 
     private java.util.Optional<ReadOnlyInternApplyMemory> readAddressBook(String filePath) throws Exception {
-        return new JsonInternApplyStorage(Paths.get(filePath)).readInternApplyMemory(addToTestDataPathIfNotNull(filePath));
+        return new JsonInternApplyStorage(Paths.get(filePath))
+                .readInternApplyMemory(addToTestDataPathIfNotNull(filePath));
     }
 
     private Path addToTestDataPathIfNotNull(String prefsFileInTestDataFolder) {

--- a/src/test/java/seedu/address/storage/JsonSerializableInternApplyTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableInternApplyTest.java
@@ -13,7 +13,7 @@ import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.InternApplyMemory;
 import seedu.address.testutil.TypicalPersons;
 
-public class JsonSerializableAddressBookTest {
+public class JsonSerializableInternApplyTest {
 
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonSerializableAddressBookTest");
     private static final Path TYPICAL_PERSONS_FILE = TEST_DATA_FOLDER.resolve("typicalPersonsAddressBook.json");
@@ -22,8 +22,8 @@ public class JsonSerializableAddressBookTest {
 
     @Test
     public void toModelType_typicalPersonsFile_success() throws Exception {
-        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
-                JsonSerializableAddressBook.class).get();
+        JsonSerializableInternApply dataFromFile = JsonUtil.readJsonFile(TYPICAL_PERSONS_FILE,
+                JsonSerializableInternApply.class).get();
         InternApplyMemory addressBookFromFile = dataFromFile.toModelType();
         InternApplyMemory typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
@@ -31,16 +31,16 @@ public class JsonSerializableAddressBookTest {
 
     @Test
     public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {
-        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_PERSON_FILE,
-                JsonSerializableAddressBook.class).get();
+        JsonSerializableInternApply dataFromFile = JsonUtil.readJsonFile(INVALID_PERSON_FILE,
+                JsonSerializableInternApply.class).get();
         assertThrows(IllegalValueException.class, dataFromFile::toModelType);
     }
 
     @Test
     public void toModelType_duplicatePersons_throwsIllegalValueException() throws Exception {
-        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_PERSON_FILE,
-                JsonSerializableAddressBook.class).get();
-        assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_PERSON,
+        JsonSerializableInternApply dataFromFile = JsonUtil.readJsonFile(DUPLICATE_PERSON_FILE,
+                JsonSerializableInternApply.class).get();
+        assertThrows(IllegalValueException.class, JsonSerializableInternApply.MESSAGE_DUPLICATE_PERSON,
                 dataFromFile::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -24,7 +24,7 @@ public class StorageManagerTest {
 
     @BeforeEach
     public void setUp() {
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(getTempFilePath("ab"));
+        JsonInternApplyStorage addressBookStorage = new JsonInternApplyStorage(getTempFilePath("ab"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
         storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
     }
@@ -55,14 +55,14 @@ public class StorageManagerTest {
          * More extensive testing of UserPref saving/reading is done in {@link JsonAddressBookStorageTest} class.
          */
         InternApplyMemory original = getTypicalAddressBook();
-        storageManager.saveAddressBook(original);
-        ReadOnlyInternApplyMemory retrieved = storageManager.readAddressBook().get();
+        storageManager.saveInternApply(original);
+        ReadOnlyInternApplyMemory retrieved = storageManager.readInternApplyMemory().get();
         assertEquals(original, new InternApplyMemory(retrieved));
     }
 
     @Test
     public void getAddressBookFilePath() {
-        assertNotNull(storageManager.getAddressBookFilePath());
+        assertNotNull(storageManager.getInternApplyFilePath());
     }
 
 }


### PR DESCRIPTION
Here are the proposed changes to morph the classes in the Storage folder to better fit InternApply.

1 things that requires your attention:

I have been unable to rename field "persons" in line 24 of "JsonSerializableInternApply" class. The method that this concerns is found in line 30.
Renaming it to "applications" results in the application failing the following testcases:

readAndSaveAddressBook_allInOrder_success() (Line 65)
addressBookReadSave() (Line 51)
Testcases can be found in:
src/test/java/seedu/address/storage/JsonInternApplyStorageTest.java
src/test/java/seedu/address/storage/StorageManagerTest.java
respectively.

I have yet to figure out a solution but the error likely comes from how Json files are being handled by the AB3 code base, This is something pretty minor but I thought I'd just jot it down here for future reference,