### PR TITLE
Expanding the edit command to allow users to edit Priority Tag and Application Status Tag

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,12 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBTITLE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -28,15 +23,19 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_PRIORITY_TAG + "PRIORITY_TAG] "
+            + "[" + PREFIX_APPLICATION_STATUS_TAG + "APPLICATION_STATUS_TAG]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Shopee "
             + PREFIX_JOBTITLE + "Software Engineer Intern "
             + PREFIX_PHONE + "87438807 "
             + PREFIX_EMAIL + "hr@shopee.sg "
             + PREFIX_ADDRESS + "5 Science Park Dr, #06-40 "
-            + PREFIX_TAG + "Software Engineering "
-            + PREFIX_JOBTITLE + "Software Engineer Intern";
+            + PREFIX_TAG + "SoftwareEngineering "
+            + PREFIX_TAG + "SingaporeBased "
+            + PREFIX_PRIORITY_TAG + "HIGH "
+            + PREFIX_APPLICATION_STATUS_TAG + "APPLIED";
 
 
     public static final String MESSAGE_SUCCESS = "New application added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,7 +1,14 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPLICATION_STATUS_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBTITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,13 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_SLOT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBTITLE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPLICATIONS;
 
 import java.util.Collections;
@@ -47,11 +41,14 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_INTERVIEW_SLOT + "[INTERVIEW SLOT (format: " + InterviewSlot.FORMAT_DATETIME_INPUT + "] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_PRIORITY_TAG + "PRIORITY_TAG] "
+            + "[" + PREFIX_APPLICATION_STATUS_TAG + "APPLICATION_STATUS_TAG]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com "
-            + PREFIX_INTERVIEW_SLOT + "25-03-2022 13:30";
+            + PREFIX_EMAIL + "johndoeinc@privateltd.com "
+            + PREFIX_INTERVIEW_SLOT + "25-03-2022 13:30 "
+            + PREFIX_APPLICATION_STATUS_TAG + "INTERVIEWED";
 
     public static final String MESSAGE_EDIT_APPLICATION_SUCCESS = "Edited Application: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,10 +1,23 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPLICATION_STATUS_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_SLOT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBTITLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPLICATIONS;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
@@ -12,7 +25,13 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.application.*;
+import seedu.address.model.application.Address;
+import seedu.address.model.application.Application;
+import seedu.address.model.application.Email;
+import seedu.address.model.application.InterviewSlot;
+import seedu.address.model.application.JobTitle;
+import seedu.address.model.application.Name;
+import seedu.address.model.application.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.TagType;
 
@@ -95,8 +114,8 @@ public class EditCommand extends Command {
         Phone updatedPhone = editApplicationDescriptor.getPhone().orElse(applicationToEdit.getPhone());
         Email updatedEmail = editApplicationDescriptor.getEmail().orElse(applicationToEdit.getEmail());
         Address updatedAddress = editApplicationDescriptor.getAddress().orElse(applicationToEdit.getAddress());
-        Set<Tag> updatedTags = editApplicationDescriptor.getTags(applicationToEdit.getTags()).
-                orElse(applicationToEdit.getTags());
+        Set<Tag> updatedTags = editApplicationDescriptor.getTags(applicationToEdit.getTags())
+                .orElse(applicationToEdit.getTags());
         InterviewSlot updatedInterviewSlot = editApplicationDescriptor.getInterviewSlot()
                 .orElse(applicationToEdit.getInterviewSlot());
 
@@ -268,6 +287,10 @@ public class EditCommand extends Command {
 
         }
 
+        /**
+         * Returns a {@code Set<Tag> destination} that contains all the Tags of a particular {@code TagType} found
+         * within a given {@code Set<Tag> source}.
+         */
         public Set<Tag> findMatchAndCopy(Set<Tag> source, Set<Tag> destination, TagType tagType) {
             Iterator<Tag> temp = source.iterator();
             while (temp.hasNext()) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -236,28 +236,31 @@ public class EditCommand extends Command {
 
             // Check if tags contains any Tag with TagType.JOB_SCOPE; this refers to a generic tag
             if (tags.stream().anyMatch(jobScope)) {
-                reconstructedTagSet = findMatchAndCopy(tags, reconstructedTagSet, jobScope);
+                reconstructedTagSet = findMatchAndCopy(tags, reconstructedTagSet, TagType.JOB_SCOPE);
             } else {
                 if (applicationToEditTags.stream().anyMatch(jobScope)) {
-                    reconstructedTagSet = findMatchAndCopy(applicationToEditTags, reconstructedTagSet, jobScope);
+                    reconstructedTagSet = findMatchAndCopy(applicationToEditTags, reconstructedTagSet,
+                            TagType.JOB_SCOPE);
                 }
             }
 
             // Check if tags contains any Tag with TagType.PRIORITY; this refers to a Priority tag
             if (tags.stream().anyMatch(priority)) {
-                reconstructedTagSet = findMatchAndCopy(tags, reconstructedTagSet, priority);
+                reconstructedTagSet = findMatchAndCopy(tags, reconstructedTagSet, TagType.PRIORITY);
             } else {
                 if (applicationToEditTags.stream().anyMatch(priority)) {
-                    reconstructedTagSet = findMatchAndCopy(applicationToEditTags, reconstructedTagSet, priority);
+                    reconstructedTagSet = findMatchAndCopy(applicationToEditTags, reconstructedTagSet,
+                            TagType.PRIORITY);
                 }
             }
 
             // Check if tags contains any Tag with TagType.APPLICATION_STATUS; this refers to Application Status tag
             if (tags.stream().anyMatch(applicationStatus)) {
-                reconstructedTagSet = findMatchAndCopy(tags, reconstructedTagSet, applicationStatus);
+                reconstructedTagSet = findMatchAndCopy(tags, reconstructedTagSet, TagType.APPLICATION_STATUS);
             } else {
                 if (applicationToEditTags.stream().anyMatch(applicationStatus)) {
-                    reconstructedTagSet = findMatchAndCopy(tags, reconstructedTagSet, applicationStatus);
+                    reconstructedTagSet = findMatchAndCopy(applicationToEditTags, reconstructedTagSet,
+                            TagType.APPLICATION_STATUS);
                 }
             }
 
@@ -265,11 +268,11 @@ public class EditCommand extends Command {
 
         }
 
-        public Set<Tag> findMatchAndCopy(Set<Tag> source, Set<Tag> destination, Predicate predicate) {
+        public Set<Tag> findMatchAndCopy(Set<Tag> source, Set<Tag> destination, TagType tagType) {
             Iterator<Tag> temp = source.iterator();
             while (temp.hasNext()) {
                 Tag tempTag = temp.next();
-                if (tempTag.getTagType() == TagType.JOB_SCOPE) {
+                if (tempTag.getTagType() == tagType) {
                     destination.add(tempTag);
                 }
             }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_SLOT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBTITLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -35,7 +36,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_JOBTITLE, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_ADDRESS, PREFIX_INTERVIEW_SLOT, PREFIX_TAG);
+                        PREFIX_ADDRESS, PREFIX_INTERVIEW_SLOT, PREFIX_TAG, PREFIX_PRIORITY_TAG);
 
         Index index;
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -22,7 +22,6 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditApplicationDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
-import seedu.address.model.tag.TagType;
 
 /**
  * Parses input arguments and creates a new EditCommand object
@@ -110,8 +109,8 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         // Checks for tag of type APPLICATION_STATUS and adds it to created tagSet.
         if (applicationStatusSet.isPresent()) {
-            Tag applicationStatusTag = ParserUtil.
-                    parseApplicationStatusTag(argMultimap.getValue(PREFIX_APPLICATION_STATUS_TAG).get());
+            Tag applicationStatusTag = ParserUtil
+                    .parseApplicationStatusTag(argMultimap.getValue(PREFIX_APPLICATION_STATUS_TAG).get());
             tagSet.add(applicationStatusTag);
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPLICATION_STATUS_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_SLOT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBTITLE;
@@ -37,7 +38,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_JOBTITLE, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_ADDRESS, PREFIX_INTERVIEW_SLOT, PREFIX_TAG, PREFIX_PRIORITY_TAG);
+                        PREFIX_ADDRESS, PREFIX_INTERVIEW_SLOT, PREFIX_TAG, PREFIX_PRIORITY_TAG,
+                        PREFIX_APPLICATION_STATUS_TAG);
 
         Index index;
 
@@ -88,20 +90,29 @@ public class EditCommandParser implements Parser<EditCommand> {
     private Optional<Set<Tag>> parseTagsForEdit(ArgumentMultimap argMultimap) throws ParseException {
         Collection<String> genericTagsSet = argMultimap.getAllValues(PREFIX_TAG);
         Optional<String> priorityTagSet = argMultimap.getValue(PREFIX_PRIORITY_TAG);
+        Optional<String> applicationStatusSet = argMultimap.getValue(PREFIX_APPLICATION_STATUS_TAG);
 
-        // Checks if argMultimap contains any generic tags or priority tags else returns an empty Optional instance
-        if (genericTagsSet.isEmpty() && !priorityTagSet.isPresent()) {
+        // Checks if argMultimap contains any generic tags, priority tags or application status tag else returns an
+        // empty Optional instance.
+        if (genericTagsSet.isEmpty() && !priorityTagSet.isPresent() && !applicationStatusSet.isPresent()) {
             return Optional.empty();
         }
 
-        // Create tagSet using generic tags if any
-        // This tagSet can either be empty or non-empty Set<Tag>
+        // Create tagSet using generic tags if any.
+        // This tagSet can either be empty or non-empty Set<Tag>.
         Set<Tag> tagSet = ParserUtil.parseTags(parseGenericTagsForEdit(genericTagsSet));
 
-        // Checks for tag of type PRIORITY and adds it to created tagSet
+        // Checks for tag of type PRIORITY and adds it to created tagSet.
         if (priorityTagSet.isPresent()) {
             Tag priorityTag = ParserUtil.parsePriorityTag(argMultimap.getValue(PREFIX_PRIORITY_TAG).get());
             tagSet.add(priorityTag);
+        }
+
+        // Checks for tag of type APPLICATION_STATUS and adds it to created tagSet.
+        if (applicationStatusSet.isPresent()) {
+            Tag applicationStatusTag = ParserUtil.
+                    parseApplicationStatusTag(argMultimap.getValue(PREFIX_APPLICATION_STATUS_TAG).get());
+            tagSet.add(applicationStatusTag);
         }
 
         return Optional.of(tagSet);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_SLOT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBTITLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -36,7 +35,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_JOBTITLE, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_ADDRESS, PREFIX_INTERVIEW_SLOT, PREFIX_TAG, PREFIX_PRIORITY_TAG);
+                        PREFIX_ADDRESS, PREFIX_INTERVIEW_SLOT, PREFIX_TAG);
 
         Index index;
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INTERVIEW_SLOT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBTITLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -20,6 +21,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditApplicationDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagType;
 
 /**
  * Parses input arguments and creates a new EditCommand object
@@ -35,7 +37,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_JOBTITLE, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_ADDRESS, PREFIX_INTERVIEW_SLOT, PREFIX_TAG);
+                        PREFIX_ADDRESS, PREFIX_INTERVIEW_SLOT, PREFIX_TAG, PREFIX_PRIORITY_TAG);
 
         Index index;
 
@@ -68,7 +70,7 @@ public class EditCommandParser implements Parser<EditCommand> {
                     .parseInterviewSlot(argMultimap.getValue(PREFIX_INTERVIEW_SLOT).get()));
         }
 
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editApplicationDescriptor::setTags);
+        parseTagsForEdit(argMultimap).ifPresent(editApplicationDescriptor::setTags);
 
         if (!editApplicationDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -78,18 +80,43 @@ public class EditCommandParser implements Parser<EditCommand> {
     }
 
     /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
-     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * Parses {@code ArgumentMultimap argMultimap} into a {@code Set<Tag>} if {@code argMultimap} is non-empty.
+     * If {@code argMultimap} contain only one element which is an empty string, it will be parsed into a
      * {@code Set<Tag>} containing zero tags.
+     * Tag includes Tags and PriorityTag.
      */
-    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
-        assert tags != null;
+    private Optional<Set<Tag>> parseTagsForEdit(ArgumentMultimap argMultimap) throws ParseException {
+        Collection<String> genericTagsSet = argMultimap.getAllValues(PREFIX_TAG);
+        Optional<String> priorityTagSet = argMultimap.getValue(PREFIX_PRIORITY_TAG);
 
-        if (tags.isEmpty()) {
+        // Checks if argMultimap contains any generic tags or priority tags else returns an empty Optional instance
+        if (genericTagsSet.isEmpty() && !priorityTagSet.isPresent()) {
             return Optional.empty();
         }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
+
+        // Create tagSet using generic tags if any
+        // This tagSet can either be empty or non-empty Set<Tag>
+        Set<Tag> tagSet = ParserUtil.parseTags(parseGenericTagsForEdit(genericTagsSet));
+
+        // Checks for tag of type PRIORITY and adds it to created tagSet
+        if (priorityTagSet.isPresent()) {
+            Tag priorityTag = ParserUtil.parsePriorityTag(argMultimap.getValue(PREFIX_PRIORITY_TAG).get());
+            tagSet.add(priorityTag);
+        }
+
+        return Optional.of(tagSet);
+    }
+
+    /**
+     * Parses {@code Collection<String> genericTags} into a {@code Collection<String>} if {@code genericTags} is
+     * non-empty.
+     * If {@code genericTags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Collection<String>} containing zero tags.
+     */
+    private Collection<String> parseGenericTagsForEdit(Collection<String> genericTags) {
+        assert genericTags != null;
+
+        return genericTags.size() == 1 && genericTags.contains("") ? Collections.emptySet() : genericTags;
     }
 
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -55,6 +55,13 @@ public class Tag {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns type of tag.
+     */
+    public TagType getTagType() {
+        return tagType;
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/test/data/JsonSerializableInternApplyMemoryTest/typicalApplicationInternApplyMemory.json
+++ b/src/test/data/JsonSerializableInternApplyMemoryTest/typicalApplicationInternApplyMemory.json
@@ -6,7 +6,7 @@
     "email" : "hr@grab.com",
     "address" : "123, Jurong West Ave 6, #08-111",
     "interviewSlot" : "13-02-2022 16:00",
-    "tagged" : [ "friends" ],
+    "tagged" : [ ],
     "jobTitle": "Intern"
   }, {
     "name" : "Lazada",

--- a/src/test/java/seedu/address/testutil/TypicalApplications.java
+++ b/src/test/java/seedu/address/testutil/TypicalApplications.java
@@ -25,26 +25,27 @@ import seedu.address.model.application.Application;
  */
 public class TypicalApplications {
 
-    public static final Application GRAB = new ApplicationBuilder().withName("Grab")
-            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("hr@grab.com")
-            .withPhone("94351253")
-            .withTags("friends").withJobTitle("Intern").withInterviewSlot("13-02-2022 16:00").build();
-    public static final Application LAZADA = new ApplicationBuilder().withName("Lazada")
-            .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("lazada@sg.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").withJobTitle("Intern").withInterviewSlot("13-03-2022 16:00").build();
+    public static final Application GRAB = new ApplicationBuilder().withName("Grab").withPhone("94351253")
+            .withEmail("hr@grab.com").withAddress("123, Jurong West Ave 6, #08-111")
+            .withInterviewSlot("13-02-2022 16:00").withJobTitle("Intern").build();
+    public static final Application LAZADA = new ApplicationBuilder().withName("Lazada").withPhone("98765432")
+            .withEmail("lazada@sg.com").withAddress("311, Clementi Ave 2, #02-25").withInterviewSlot("13-03-2022 16:00")
+            .withTags("owesMoney", "friends").withJobTitle("Intern").build();
     public static final Application SEAGROUP = new ApplicationBuilder().withName("SEA Group").withPhone("95352563")
-            .withEmail("sea@hr.com").withAddress("1 Fusionopolis Place, #17-10, Galaxis, 138522").build();
+            .withEmail("sea@hr.com").withAddress("1 Fusionopolis Place, #17-10, Galaxis, 138522").withJobTitle("Intern")
+            .build();
     public static final Application SEATALK = new ApplicationBuilder().withName("SEA Talk").withPhone("87652533")
-            .withEmail("sea@hr.com").withAddress("1 Fusionopolis Place, #17-10, Galaxis, 138522")
-            .withTags("friends").build();
+            .withEmail("sea@hr.com").withAddress("1 Fusionopolis Place, #17-10, Galaxis, 138522").withTags("friends")
+            .withJobTitle("Intern").build();
     public static final Application SEAMONEY = new ApplicationBuilder().withName("SEA Money").withPhone("9482224")
-            .withEmail("sea@hr.com").withAddress("1 Fusionopolis Place, #17-10, Galaxis, 138522").build();
+            .withEmail("sea@hr.com").withAddress("1 Fusionopolis Place, #17-10, Galaxis, 138522").withJobTitle("Intern")
+            .build();
     public static final Application SEACLOUD = new ApplicationBuilder().withName("Cloud").withPhone("9482427")
-            .withEmail("sea@hr.com").withAddress("77 Robinson Rd, #13-00 Robinson 77, 068896").build();
-    public static final Application SEAMARKETPLACE = new ApplicationBuilder()
-            .withName("Marketplace").withPhone("9482442")
-            .withEmail("sea@hr.com").withAddress("77 Robinson Rd, #13-00 Robinson 77, 068896").build();
+            .withEmail("sea@hr.com").withAddress("77 Robinson Rd, #13-00 Robinson 77, 068896").withJobTitle("Intern")
+            .build();
+    public static final Application SEAMARKETPLACE = new ApplicationBuilder().withName("Marketplace")
+            .withPhone("9482442").withEmail("sea@hr.com").withAddress("77 Robinson Rd, #13-00 Robinson 77, 068896")
+            .withJobTitle("Intern").build();
 
     // Manually added
     public static final Application VISA = new ApplicationBuilder().withName("VISA").withPhone("8482424")


### PR DESCRIPTION
# Expanding the edit command to allow users to edit Priority Tag and Application Status Tag

## Key Summary
- `edit` command now recognizes `/ast` and `/pt` prefix
- Users can now use the `edit` command to edit the application status or priority of existing applications
- The implementation of the edit command has been adjusted such that the editing of tags is more specific and will not cause issues like `edit 1 t/local pt/HIGH` causing the application status of the existing application to be wiped. **This was done without changing the implementation of Tag, PriorityTag and ApplicationStatusTag.**

## Other Things to Note
- Changes were made to some files for the JUnit test; details below
- As a result of the tweaking of the `edit` command, there is no longer a way for users to **deliberately "clear" tags** using the `edit` command by typing `edit 1 /t` for example. This "feature" could be brought up for further discussion in the future.

## Changes Made to the Code
- No new classes were created
- Existing classes that were modified:
### EditCommandParser.java
    a. Tokenizer in the parse() method was changed to include checking for `/ast` and `/pt` prefixes.
    b. parseTagsForEdit() was heavily modified; it now checks for any changes to make to all the three Tag classes and makes sure the changes are correctly reflected in the final Optional<Set<Tag>> it returns.
    c. parseGenericTagsForEdit() method was created to help with the longer parseTagsForEdit() method.
### AddCommand.java
    a. MESSAGE_USAGE of the following classes have also been updated
### EditCommand.java
    a. MESSAGE_USAGE of the following classes have also been updated
### EditCommand.java
    a. Another implementation of the getTags() method has been created. This method specifically deals with the logic of preventing accidental wiping of existing tags that weren't being edited by the user.
    b. findMatchAndCopy() method has been created to help with the new and longer getTags() method.
    c. A new TagSetContainsTagTypePredicate() static class was created within EditCommand.java also to help with the new and longer getTags() method.
### typicalApplicationInternApplyMemory.json
     a. Minor change made 
### TypicalApplication.java
     a. Minor change made 

## Feedback that I would like
As mentioned above, there is no longer a way to **deliberately "clear" tags** anymore. However, I might be able to find a workaround such that `edit 1 /t ast/REJECTED` for example would clear the tags of the applications while still editing the application status of the application and **more importantly** recover the existing Prioirity tag.

However, I won't be able to do the same of `ast/` and `pt/` since for those prefixes, an alphanumeric argument is expected to be passed it based on existing implementation of Application Status Tag and Prioirty Tag.

So, would you guys rather:
1) Users will just not be able to "clear" tags anymore; but we could consider implementing this as a separate feature in the future.
2) Users will be allowed to deliberately "clear" tags but this won't extend to `ast/` and `pt/` tags.
    
Ready for review @joszx @laughingkid-sg @yongler @tanyutao544 (anyone will do)

Implements #102