### PR TITLE
Docs - Update UG for edit command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -100,7 +100,7 @@ Format: `list`
 
 Edits an existing application in SoC InternApply.
 
-Format: `edit INDEX [n/NAME] [j/JOB_TITLE] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [idt/INTERVIEW_DATE_TIME] [d/DETAILS] [t/TAG]... \`
+Format: `edit INDEX [n/NAME] [j/JOB_TITLE] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [idt/INTERVIEW_DATE_TIME] [d/DETAILS] [t/TAG]... [pt/PRIORITY_TAG] [ast/APPLICATION_STATUS_TAG]\`
 - Edits the application at the specified `INDEX`. The index refers to the index number shown in the displayed application list. The index **must be a positive integer** 1, 2, 3, ...
 - At least one of the optional fields must be provided.
 - Existing values will be updated to the input values.
@@ -108,12 +108,13 @@ Format: `edit INDEX [n/NAME] [j/JOB_TITLE] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS
 - The interview date time, `INTERVIEW_DATE_TIME`, must in the follow format `dd-MM-yyyy HH:mm`.
 - You can add details to the application by using `d/DETAILS`
 - You can enter new lines in the details by using `\n`
-- You can remove all the application's `TAG`'s by typing `t/` without specifying any tags after it.
+
 - You can remove `INTERVIEW_DATE_TIME` by typing `idt/` without specifying any tags after it.
-- When editing `TAG`'s, the existing tags of the application will be removed.
+- When editing `TAG`'s, the `TAG`'s that are not specified by the user will be filled in using the corresponding `TAG`'s within the existing application.
 
 Examples:
 - `edit 1 e/SoCStudent@example.com n/NUS Research` Edits the email and name of the 1st application to be `SoCStudent@example.com` and `NUS Research` respectively.
+- `edit 1 t/Singapore ast/APPLIED` Edits the tags and application status tag of the 1st application to Singapore and APPLIED respectively. Since the priority tag is not specified, the 1st application will keep it's current priority tag if it had any.
 - `edit 2 j/Intern idt/` Edits the job title of the 2nd application to be `Intern` and clears the existing interview date time.
 - `edit 1 d/Example details \nThis is a newline of the details` Edits the details to be:
 ```


### PR DESCRIPTION
Update the UG to reflect the changes made to the `edit` command to allow the editing of priority tag and application status tag of any specified application using the prefix pt/ and ast/ respectively.

Fix #124