### PR TITLE
Fix - UI not showing all elements

### DIFF
--- a/src/main/resources/view/ApplicationListCard.fxml
+++ b/src/main/resources/view/ApplicationListCard.fxml
@@ -29,11 +29,11 @@
           <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
         </HBox>
         <HBox fx:id="tags" />
-        <Label fx:id="jobTitle" styleClass="cell_small_label" text="\$jobTitle" />
-        <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-        <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-        <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-        <Label fx:id="interviewSlot" styleClass="cell_small_label" text="\$interviewSlot" />
+        <Label fx:id="jobTitle" styleClass="cell_small_label" text="\$jobTitle" wrapText="true"/>
+        <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true"/>
+        <Label fx:id="address" styleClass="cell_small_label" text="\$address" wrapText="true"/>
+        <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>
+        <Label fx:id="interviewSlot" styleClass="cell_small_label" text="\$interviewSlot" wrapText="true"/>
       </VBox>
       <ScrollPane fx:id="detailScroll" maxHeight="145.0" minWidth="400" maxWidth="400" styleClass="pane-with-border" hbarPolicy="NEVER">
         <content>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="InternApply" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="1000"  onCloseRequest="#handleExit" title="InternApply" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/address_book_32.png" />
     </icons>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="600" minWidth="1000"  onCloseRequest="#handleExit" title="InternApply" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="1200"  onCloseRequest="#handleExit" title="InternApply" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/address_book_32.png" />
     </icons>


### PR DESCRIPTION
# Key Summary
- update MainWindow UI to minWidth to 1200
- Set textwrap on applicationCard labels

## Files changed
- MainWindow.fxml
  - minWidth="1200"
- ApplicationListCard.fxml
  - add wrapText = true to labels

## Notes
The results box should now be large enough to display all fields in 2-3 lines
default width is 1200 which is safe in the bounds of displays of size 1280 x 720