### PR TITLE
Fix normal tag same name as priority or status tag

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -168,7 +168,7 @@ public class ParserUtil {
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
-        if (Tag.isPriorityApplicationStatus(tag.toUpperCase())){
+        if (Tag.isPriorityApplicationStatus(tag)){
             throw new ParseException(Tag.TAG_NAME_CONSTRAINTS);
         }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -168,6 +168,9 @@ public class ParserUtil {
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
+        if (Tag.isPriorityApplicationStatus(tag.toUpperCase())){
+            throw new ParseException(Tag.TAG_NAME_CONSTRAINTS);
+        }
 
         return new Tag(trimmedTag, TagType.JOB_SCOPE);
     }
@@ -223,5 +226,6 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -168,7 +168,7 @@ public class ParserUtil {
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
-        if (Tag.isPriorityApplicationStatus(tag)){
+        if (Tag.isPriorityApplicationStatus(tag)) {
             throw new ParseException(Tag.TAG_NAME_CONSTRAINTS);
         }
 

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,6 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
     public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric and not be empty";
+    public static final String TAG_NAME_CONSTRAINTS = "Tag name should not be a priority or application status type";
     public static final String VALIDATION_REGEX = "^[A-Za-z0-9_]+$";
 
     public final String tagName;
@@ -53,6 +54,13 @@ public class Tag {
      */
     public static boolean isValidTagName(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string matches priority or application status tag name
+     */
+    public static boolean isPriorityApplicationStatus(String test) {
+        return (PriorityTagType.contains(test) || ApplicationStatusTagType.contains(test));
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -60,7 +60,7 @@ public class Tag {
      * Returns true if a given string matches priority or application status tag name
      */
     public static boolean isPriorityApplicationStatus(String test) {
-        return (PriorityTagType.contains(test) || ApplicationStatusTagType.contains(test));
+        return (PriorityTagType.contains(test.toUpperCase()) || ApplicationStatusTagType.contains(test.toUpperCase()));
     }
 
     /**


### PR DESCRIPTION
# Key Summary
- Update parser to prevent a user from inputting priority or status tag names into the regular tag field

## files changed
- ParserUtil
  - new check, in TagParser to test if the tag name provided is identical to the priority or status tag
- Tag
  - new method to check if a string given is equal to priority or status tag

Implements #182 