### PR TITLE
Bug - Reverse order for sorting priority

### DIFF
--- a/src/main/java/seedu/address/logic/sort/PriorityComparator.java
+++ b/src/main/java/seedu/address/logic/sort/PriorityComparator.java
@@ -22,18 +22,15 @@ public class PriorityComparator implements Comparator<Application> {
         int compareResult = getPriorityRanking(o1.getPriorityTag()) - getPriorityRanking(o2.getPriorityTag());
         return compareResult == 0
                 ? o1.getName().toString().compareTo(o2.getName().toString())
-                : -compareResult;
+                : compareResult;
     }
 
     private int getPriorityRanking(Optional<Tag> t) {
         if (t.isEmpty()) {
             return 0;
-        } else if (t.get().toString().equals(PriorityTagType.LOW.toString())) {
-            return 1;
-        } else if (t.get().toString().equals(PriorityTagType.MEDIUM.toString())) {
-            return 2;
         } else {
-            return 3;
+            PriorityTagType priorityTagType = PriorityTagType.valueOf(t.get().toString());
+            return priorityTagType.getPriorityRanking();
         }
     }
 

--- a/src/main/java/seedu/address/model/tag/PriorityTagType.java
+++ b/src/main/java/seedu/address/model/tag/PriorityTagType.java
@@ -7,7 +7,17 @@ import java.util.stream.Stream;
  * A public enumeration class for priority tags.
  */
 public enum PriorityTagType {
-    HIGH, MEDIUM, LOW;
+    HIGH(3), MEDIUM(2), LOW(1);
+
+    private final int priorityRanking;
+
+    PriorityTagType(int priorityRanking) {
+        this.priorityRanking = priorityRanking;
+    }
+
+    public int getPriorityRanking() {
+        return this.priorityRanking;
+    }
 
     /**
      * Gets all enum values as strings.

--- a/src/test/java/seedu/address/model/application/InterviewSlotTest.java
+++ b/src/test/java/seedu/address/model/application/InterviewSlotTest.java
@@ -39,9 +39,7 @@ public class InterviewSlotTest {
         assertFalse(InterviewSlot.isValidDateTime("30-03-2022 1530")); // missing minutes separator
 
         // invalid parts
-        // TODO: Update February parsing issue.
-        // February has a leap year issue and accepting dates more than 29.
-        //assertFalse(InterviewSlot.isValidDateTime("30-02-2022 15:30")); // invalid date
+        assertFalse(InterviewSlot.isValidDateTime("30-02-2022 15:30")); // invalid date
         assertFalse(InterviewSlot.isValidDateTime("30/03/2022 15:30")); // invalid date separator
         assertFalse(InterviewSlot.isValidDateTime("03-30-2022 15:30")); // invalid month
         assertFalse(InterviewSlot.isValidDateTime("32-02-2022 15:30")); // invalid date


### PR DESCRIPTION
Reverse order for sorting priority

New sorting order ascending - `<no-tag>`, `low`, `medium`, `high`

Fixes #154 