### PR TITLE
Fix PED bugs and more extensive testing

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -347,5 +347,4 @@ Action | Format, Examples
 [**List**](#listing-all-applications-in-a-sorted-manner-list) | `list [sorting paramter] [order by]`
 [**Reminder**](#listing-applications-with-upcoming-interviews-reminder)| `reminder`
 
-
 [Go To TOC](#table-of-contents)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -229,6 +229,7 @@ Finds existing applications in SoC InternApply.
 - Finds the applications with the fields containing keywords given in the input (partial keywords accepted as well).
 - Keywords are case-insensitive.
 - Parameters are only expected once (except tags). e.g. `find n/shopee n/grab` is equivalent to `find n/grab`, the last occurrence of the parameter will be taken.
+- However, for `n/` and `j`, more than 1 word can be accepted per field i.e. `find n/aftershock pc` will display any application with the name `aftershock` or `pc`. 
 - If more than 1 different fields are given, i.e. `find n/shopee j/ML`, only the first field (in the sequence of [n/NAME], [j/JOB_TITLE], [t/TAG]..., [pt/PRIORITY_TAG], [ast/APPLICATION_STATUS_TAG]) will be processed, i.e. `find n/shopee j/ML` is the same as `find n/shopee`, `find j/ML n/shopee` is also the same as `find n/shopee`
 
 **Example usages and expected outcomes:**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -229,7 +229,7 @@ Finds existing applications in SoC InternApply.
 - Finds the applications with the fields containing keywords given in the input.
 - Keywords are case-insensitive.
 - Parameters are only expected once (except tags). e.g. `find n/shopee n/grab` is equivalent to `find n/grab`, the last occurrence of the parameter will be taken.
-- If more than 1 different fields are given, i.e. `find n/shopee j/ML`, only the first field will be processed, i.e. `find n/shopee j/ML` is the same as `find n/shopee`
+- If more than 1 different fields are given, i.e. `find n/shopee j/ML`, only the first field (in the sequence of [n/NAME], [j/JOB_TITLE], [t/TAG]..., [pt/PRIORITY_TAG], [ast/APPLICATION_STATUS_TAG]`) will be processed, i.e. `find n/shopee j/ML` is the same as `find n/shopee`, `find j/ML n/shopee` is also the same as `find n/shopee`
 
 **Example usages and expected outcomes:**
 - `find n/shopee` finds and displays all applications with "Shopee" in its name.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -30,7 +30,7 @@ Ultimately, with SoC InternApply, you can worry less about the administrative ta
 3. Copy the file to the folder you want to use as the _root folder_ for your SIA (e.g. you can save it in your desktop or downloads folder). <br>
    **Note:** There will be data (your internship applications) stored into this same folder, but it would not take up much space.
 
-4. Double-click the jar file to start the app. The GUI similar to the diagram below should appear in a few seconds. Note how the app contains some sample data.<br><br>
+4. Double-click the jar file to start the app. The GUI similar to the diagram below should appear in a few seconds. Note how the app contains some sample data. Do note that for Linux OS, you may have to enable double-click to run JAR files first!<br><br>
 
    ![Ui](images/MainWindowUi.png)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -5,13 +5,13 @@ title: User Guide
 
 SoC InternApply (SIA) is a **desktop app for managing internship applications, optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, SIA can get your internship application management tasks done faster than traditional GUI apps.
 
-With SoC InternApply, you can easily add an application, edit it later on if there are any changes needed, find the applications based on keywords and also sort them based on priority, interview date and much more! All while not having to worry about saving or storing your applications as this is done internally and automatically by SoC InternApply. 
+With SoC InternApply, you can easily add an application, edit it later on if there are any changes needed, find the applications based on keywords and also sort them based on priority, interview date and much more! All while not having to worry about saving or storing your applications as this is done internally and automatically by SoC InternApply.
 
 Ultimately, with SoC InternApply, you can worry less about the administrative tasks and focus more on preparing for the interviews themselves!
 
 ## Table of Contents
 * Table of Contents
-{:toc}
+  {:toc}
 
 --------------------------------------------------------------------------------------------------------------------
 ## Glossary
@@ -23,12 +23,12 @@ Ultimately, with SoC InternApply, you can worry less about the administrative ta
 
 ## Quick start
 
-1. Ensure you have Java `11` or above installed in your Computer. You can download it from [this website](https://www.oracle.com/sg/java/technologies/javase/jdk11-archive-downloads.html). 
+1. Ensure you have Java `11` or above installed in your Computer. You can download it from [this website](https://www.oracle.com/sg/java/technologies/javase/jdk11-archive-downloads.html).
 
 2. Download the latest `internapply.jar` from [here](https://github.com/AY2122S2-CS2103T-T11-3/tp/releases).
 
 3. Copy the file to the folder you want to use as the _root folder_ for your SIA (e.g. you can save it in your desktop or downloads folder). <br>
-**Note:** There will be data (your internship applications) stored into this same folder, but it would not take up much space.
+   **Note:** There will be data (your internship applications) stored into this same folder, but it would not take up much space.
 
 4. Double-click the jar file to start the app. The GUI similar to the diagram below should appear in a few seconds. Note how the app contains some sample data.<br><br>
 
@@ -38,25 +38,25 @@ Ultimately, with SoC InternApply, you can worry less about the administrative ta
    ![Ui](images/ReminderWindowUi.png)
 6. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window.<br>
    Some example commands you can try:
-   * **`add`**`n/Shopee j/Software Engineer Intern p/87438807 e/hr@shopee.sg a/5 Science Park Dr, #06-40 t/SoftwareEngineering pt/LOW ast/NOT_APPLIED` : Adds an application with company named `Shopee` to SIA.
-   
-   * **`clear`** : Deletes all applications.
+    * **`add`**`n/Shopee j/Software Engineer Intern p/87438807 e/hr@shopee.sg a/5 Science Park Dr, #06-40 t/SoftwareEngineering pt/LOW ast/NOT_APPLIED` : Adds an application with company named `Shopee` to SIA.
 
-   * **`delete`**`3` : Deletes the 3rd application shown in the current list.
+    * **`clear`** : Deletes all applications.
 
-   * **`edit`** `1 d/Thank you for using SIA!` : Update the details to `Thank you for using SIA!` for the first application on the list.
+    * **`delete`**`3` : Deletes the 3rd application shown in the current list.
 
-   * **`edit`**`1 idt/17-03-2022 16:00` : Update the interview slot to `17 Mar 2022 16:00` for the first application on the list.
+    * **`edit`** `1 d/Thank you for using SIA!` : Update the details to `Thank you for using SIA!` for the first application on the list.
 
-   * **`exit`** : Exits the app.
+    * **`edit`**`1 idt/17-03-2022 16:00` : Update the interview slot to `17 Mar 2022 16:00` for the first application on the list.
 
-   * **`find`**`n/shopee` : Find all applications that contain the word "Shopee" in its name.
+    * **`exit`** : Exits the app.
 
-   * **`help`** : Shows a message explaining how to access the help page.
-    
-   * **`list`**`name desc` : Sort all applications base on company name in descending order. 
+    * **`find`**`n/shopee` : Find all applications that contain the word "Shopee" in its name.
 
-   * **`reminder`** : Lists all applications with upcoming interviews within a week from now.
+    * **`help`** : Shows a message explaining how to access the help page.
+
+    * **`list`**`name desc` : Sort all applications base on company name in descending order.
+
+    * **`reminder`** : Lists all applications with upcoming interviews within a week from now.
 
 7. Refer to the [Features](#features) below for details of each command.
 
@@ -69,7 +69,7 @@ Edit at your own risk of losing data.
 
 </div>
 
-[Go To TOC](#table-of-contents) 
+[Go To TOC](#table-of-contents)
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -100,7 +100,7 @@ Edit at your own risk of losing data.
 
 **:information_source: Notes about the input format:**<br>
 
-* For `[t/TAG]...`, only alphanumeric inputs are allowed. i.e. Only the characters A-Z, a-z, 0-9.<br> 
+* For `[t/TAG]...`, only alphanumeric inputs are allowed. i.e. Only the characters A-Z, a-z, 0-9.<br>
   e.g. `t/Based In Singapore` is not allowed, `t/BasedInSingapore` is allowed.
 
 * For `[pt/PRIORITY_TAG]`, user input can only be any one of these: `HIGH`, `MEDIUM`, `LOW`<br>
@@ -112,7 +112,7 @@ Edit at your own risk of losing data.
 * For `[pt/PRIORITY_TAG]` and `[ast/APPLICATION_STATUS_TAG]`, the inputs are case-insensitive<br>
   e.g. `pt/HIGH` can be inputted with `pt/high` and `ast/INTERVIEWD` can be inputted with `ast/Interviewed`
 
-* For `[j/JobTitle]...`, only alphanumeric inputs are allowed. i.e. Only the characters A-Z, a-z, 0-9. Spaces are also allowed. <br> 
+* For `[j/JobTitle]...`, only alphanumeric inputs are allowed. i.e. Only the characters A-Z, a-z, 0-9. Spaces are also allowed. <br>
   e.g. `j/SoftwareEngineerIntern` is allowed, `t/Software Engineer Intern` is also allowed.
 
 
@@ -226,10 +226,10 @@ Exits the program.
 Finds existing applications in SoC InternApply.
 
 **Format:** `find [n/NAME] or find [j/JOB_TITLE] or find [t/TAG]... or find [pt/PRIORITY_TAG] or find [ast/APPLICATION_STATUS_TAG]`
-- Finds the applications with the fields containing keywords given in the input.
+- Finds the applications with the fields containing keywords given in the input (partial keywords accepted as well).
 - Keywords are case-insensitive.
 - Parameters are only expected once (except tags). e.g. `find n/shopee n/grab` is equivalent to `find n/grab`, the last occurrence of the parameter will be taken.
-- If more than 1 different fields are given, i.e. `find n/shopee j/ML`, only the first field (in the sequence of [n/NAME], [j/JOB_TITLE], [t/TAG]..., [pt/PRIORITY_TAG], [ast/APPLICATION_STATUS_TAG]`) will be processed, i.e. `find n/shopee j/ML` is the same as `find n/shopee`, `find j/ML n/shopee` is also the same as `find n/shopee`
+- If more than 1 different fields are given, i.e. `find n/shopee j/ML`, only the first field (in the sequence of [n/NAME], [j/JOB_TITLE], [t/TAG]..., [pt/PRIORITY_TAG], [ast/APPLICATION_STATUS_TAG]) will be processed, i.e. `find n/shopee j/ML` is the same as `find n/shopee`, `find j/ML n/shopee` is also the same as `find n/shopee`
 
 **Example usages and expected outcomes:**
 - `find n/shopee` finds and displays all applications with "Shopee" in its name.
@@ -243,11 +243,11 @@ Finds existing applications in SoC InternApply.
 
 ### Viewing help: `help`
 
-This command displays a message explaining how to access the help page. 
+This command displays a message explaining how to access the help page.
 
 **Format:** `help`
 
-**Example usages:** 
+**Example usages:**
 
 `help`
 
@@ -264,7 +264,7 @@ Sorts the list of all application in SoC InternApply base on the provided parame
 
 **Format:** `list [sorting paramter] [order by]`
 
-Sorting parameters: 
+Sorting parameters:
 - `name` : Sort by name of the company in alphabetical order starting with A in ascending order.
 - `interview` : Sort by interview date of applications starting with the latest earliest date.
 - `priority` : Sort by priority in the following order - HIGH, MEDIUM, LOW.
@@ -279,12 +279,12 @@ Order by:
 Examples:
 * `list interview desc`
 * `list name desc`, running this will output:
-<br>
+  <br>
 ```
 Sorted applications by name order by desc.
 ```
 
-> 💡 The `list` command also works without parameters. It will be reverted to the last sorted parameter and order used by the user. This is used after using the `find` feature to list out all applications. 
+> 💡 The `list` command also works without parameters. It will be reverted to the last sorted parameter and order used by the user. This is used after using the `find` feature to list out all applications.
 
 > ⚠️ Applications are originally sorted in  a chronological order base on create date and time. Do take note that after using the `list` feature to sort, you will not be able to sort the applications in chronological order.
 

--- a/docs/team/yongler.md
+++ b/docs/team/yongler.md
@@ -5,26 +5,56 @@ title: Lee Yong Ler's Project Portfolio Page
 
 ### Project: SoC InternApply
 
-`to be added soon`
-
 SoC InternApply - SoC InternApply helps CS students to track internship applications they are interested in. It is optimised for users who prefer CLI and have a lot of company applications and their associated tasks to keep track of. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
 
 Given below are my contributions to the project.
 
-* **New Feature**:
+**Code contributed**: 
+[Link to my code contribution](https://nus-cs2103-ay2122s2.github.io/tp-dashboard/?search=yongler&breakdown=true)
 
-* **New Feature**: 
 
-* **Code contributed**: 
 
-* **Project management**:
+**Enhancements to existing features**:
+1. Extension of normal `Tag` to `PriorityTag` and `ApplicationStatusTag`. This aids in adding more information for the applications.
+- I made changes in `Tag.java` , `PriorityTag.java` , `PriorityTagType.java`, `ApplicationStatusTag.java` and `ApplicationStatusTagType.java`.
+- It is complete as required by our application as the important information about 1 application is captured by the `ApplicationStatusTag` and `PriorityTag`. If user wants to add more information, they can do so with the normal `Tag`.
+- Changes include inheritance, error messages, enumerations as well as checking of input values based on enum values, which are used in many other places such as the parsers and storage.
 
-* **Enhancements to existing features**:
 
-* **Documentation**:
+2. `Find` command such that it can find applications based on `Name`, `JobTitle`, `Tag`, `ApplicationStatusTag` and `PriorityTag`.
+- Most of the changes is in `FindCommandParser.java` , `StringUtil.java` and `FindCommand.java`.
+- The feature is complete in a way that it offers users great flexibility in filtering applications based on the important criteria.
+- Initially it was hard to implement as the mechanism of the original `Find` command was hard to trace, I looked through the code all the way to `LogicManager`. After understanding it, I had to code additional checks for the parser since it is different based on the ones used in the `Add` command.
 
-* **Community**:
+**Contributions to the UG**:
+- `Add` command for the new `PriorityTag` and `ApplicationStatusTag`.
+- `Find` command.
 
-* **Tools**:
+Other than these 2 features which I was involved in creating, I also helped to do these across the whole UG:
+- Change the UG based on Ms. Dara (CS2101 tutor)'s recommendation
+- Rewrite many confusing statements so that they are more user-friendly, where non-tech people could understand the UG
+- Make the command summary more readable 
+- Fix typos and grammar mistakes
+- Added notes and cautions for the user so that they know it is an intended behaviour
+
+**Contributions to the DG**:
+
+**Contributions to team-based tasks**:
+1. Setting up the GitHub team org/repo
+2. Setting up tools e.g., GitHub, Gradle 
+3. Maintaining the issue tracker
+4. Release management
+5. Updating user/developer docs that are not specific to a feature e.g. making it more user-friendly 
+6. Guide the team through project deliverables and give working suggestions during team meetings
+
+
+**Review/mentoring contributions**:
+- [Link to reviewed PRs](https://github.com/AY2122S2-CS2103T-T11-3/tp/issues?q=reviewed-by%3Ayongler)
+- Also helped teammates during team meeting about possible bugs in the features as well as provide links that might be useful (issue regarding environment variables and also sorting based on Java enum).  
+
+**Contributions beyond the project team**:
+- Shared Intellij shortcut tip in the forum. [Link](https://github.com/nus-cs2103-AY2122S2/forum/issues/234)
+- Helped to spot bugs from other teams during the demo PE.
+
 
 

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Helper functions for handling strings.
@@ -27,15 +28,14 @@ public class StringUtil {
         requireNonNull(sentence);
         requireNonNull(word);
 
-        String preppedWord = word.trim();
+        String preppedWord = word.trim().toLowerCase(Locale.ROOT);
         checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
         checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
 
-        String preppedSentence = sentence;
+        String preppedSentence = sentence.toLowerCase(Locale.ROOT);
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
-        return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+        return preppedSentence.contains(preppedWord);
     }
 
     /**

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.Locale;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -44,17 +44,17 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             String keyword = checkNotEmptyName(argMultimap.getValue(PREFIX_NAME).get());
-            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(keyword)));
+            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(keyword.split(" "))));
         }
         if (argMultimap.getValue(PREFIX_JOBTITLE).isPresent()) {
             String keyword = checkNotEmptyJobTitle(argMultimap.getValue(PREFIX_JOBTITLE).get());
-            return new FindCommand(new JobTitleContainsKeywordsPredicate(Arrays.asList(keyword)));
+            return new FindCommand(new JobTitleContainsKeywordsPredicate(Arrays.asList(keyword.split(" "))));
         }
         if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
             Collection<String> keywords = checkNotEmptyTags(argMultimap.getAllValues(PREFIX_TAG));
             return new FindCommand(new TagContainsKeywordsPredicate(new ArrayList<>(keywords)));
         }
-        if (argMultimap.getValue(PREFIX_PRIORITY_TAG).isPresent()) {
+    if (argMultimap.getValue(PREFIX_PRIORITY_TAG).isPresent()) {
             String keyword = checkNotEmptyPriorityTag(argMultimap.getValue(PREFIX_PRIORITY_TAG).get());
             return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(keyword)));
         }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -54,7 +54,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             Collection<String> keywords = checkNotEmptyTags(argMultimap.getAllValues(PREFIX_TAG));
             return new FindCommand(new TagContainsKeywordsPredicate(new ArrayList<>(keywords)));
         }
-    if (argMultimap.getValue(PREFIX_PRIORITY_TAG).isPresent()) {
+        if (argMultimap.getValue(PREFIX_PRIORITY_TAG).isPresent()) {
             String keyword = checkNotEmptyPriorityTag(argMultimap.getValue(PREFIX_PRIORITY_TAG).get());
             return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(keyword)));
         }

--- a/src/main/java/seedu/address/model/application/Name.java
+++ b/src/main/java/seedu/address/model/application/Name.java
@@ -11,12 +11,15 @@ public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String FIND_MESSAGE_CONSTRAINTS =
+            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String FIND_COMMAND_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/application/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/application/TagContainsKeywordsPredicate.java
@@ -8,7 +8,6 @@ import seedu.address.model.tag.ApplicationStatusTagType;
 import seedu.address.model.tag.PriorityTagType;
 import seedu.address.model.tag.Tag;
 
-
 /**
  * Tests that a {@code Application}'s {@code Tag} matches any of the keywords given.
  */

--- a/src/main/java/seedu/address/model/application/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/application/TagContainsKeywordsPredicate.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
-import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.*;
 
 
 /**
@@ -21,6 +21,9 @@ public class TagContainsKeywordsPredicate implements Predicate<Application> {
     public boolean test(Application application) {
         StringBuilder builder = new StringBuilder();
         for (Tag tag : application.getTags()) {
+            if (PriorityTagType.contains(tag.toString()) || ApplicationStatusTagType.contains(tag.toString())) {
+                continue;
+            }
             builder.append(tag.toString());
             builder.append(" ");
         }

--- a/src/main/java/seedu/address/model/application/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/application/TagContainsKeywordsPredicate.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
-import seedu.address.model.tag.*;
+import seedu.address.model.tag.ApplicationStatusTagType;
+import seedu.address.model.tag.PriorityTagType;
+import seedu.address.model.tag.Tag;
 
 
 /**

--- a/src/main/java/seedu/address/model/tag/ApplicationStatusTagType.java
+++ b/src/main/java/seedu/address/model/tag/ApplicationStatusTagType.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 public enum ApplicationStatusTagType {
     NOT_APPLIED, APPLIED, INTERVIEWED, REJECTED, ACCEPTED;
 
+    //Solution below adapted from https://stackoverflow.com/questions/1104975/a-for-loop-to-iterate-over-an-enum-in-java
     /**
      * Gets all enum values as strings.
      * @return All enum values as a concatenated string.
@@ -19,6 +20,7 @@ public enum ApplicationStatusTagType {
                 .collect(Collectors.joining(", "));
     }
 
+    //Solution below adapted from https://stackoverflow.com/questions/1104975/a-for-loop-to-iterate-over-an-enum-in-java
     /**
      * Checks whether the given string is within the enum values.
      * @param test String to test.

--- a/src/main/java/seedu/address/model/tag/PriorityTagType.java
+++ b/src/main/java/seedu/address/model/tag/PriorityTagType.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 public enum PriorityTagType {
     HIGH, MEDIUM, LOW;
 
+    //Solution below adapted from https://stackoverflow.com/questions/1104975/a-for-loop-to-iterate-over-an-enum-in-java
     /**
      * Gets all enum values as strings.
      * @return All enum values as a concatenated string.
@@ -19,6 +20,7 @@ public enum PriorityTagType {
                 .collect(Collectors.joining(", "));
     }
 
+    //Solution below adapted from https://stackoverflow.com/questions/1104975/a-for-loop-to-iterate-over-an-enum-in-java
     /**
      * Checks whether the given string is within the enum values.
      * @param test String to test.

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -8,7 +8,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
 public class Tag {
-    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric, without spaces and not be empty";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Tag names should be alphanumeric, without spaces and not be empty";
     public static final String TAG_NAME_CONSTRAINTS = "Tag name should not be a priority or application status type";
     public static final String VALIDATION_REGEX = "^[A-Za-z0-9_]+$";
 

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -8,7 +8,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
 public class Tag {
-    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric and not be empty";
+    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric, without spaces and not be empty";
     public static final String TAG_NAME_CONSTRAINTS = "Tag name should not be a priority or application status type";
     public static final String VALIDATION_REGEX = "^[A-Za-z0-9_]+$";
 

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -109,7 +109,6 @@ public class StringUtilTest {
         assertFalse(StringUtil.containsWordIgnoreCase("    ", "123"));
 
         // Matches a partial word only
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
         assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
 
         // Matches word in the sentence, different upper/lower case letters

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -10,10 +10,15 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.application.*;
+import seedu.address.model.application.JobTitle;
+import seedu.address.model.application.JobTitleContainsKeywordsPredicate;
+import seedu.address.model.application.Name;
+import seedu.address.model.application.NameContainsKeywordsPredicate;
+import seedu.address.model.application.TagContainsKeywordsPredicate;
 import seedu.address.model.tag.ApplicationStatusTag;
 import seedu.address.model.tag.PriorityTag;
 import seedu.address.model.tag.Tag;
+
 
 public class FindCommandParserTest {
 
@@ -39,11 +44,11 @@ public class FindCommandParserTest {
         FindCommand expectedFindApplicationStatusTagCommand =
                 new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("APPLIED")));
 
-        String nameArray[] = new String[] {"Grab", "Shopee" };
+        String[] nameArray = new String[]{"Grab", "Shopee"};
         FindCommand expectedFindCommandWithTwoNamesKeyword =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameArray)));
 
-        String jobTitleArray[] = new String[] {"Software", "Engineering"};
+        String[] jobTitleArray = new String[]{"Software", "Engineering"};
         FindCommand expectedFindCommandWithTwoJobTitleKeyword =
                 new FindCommand(new JobTitleContainsKeywordsPredicate(Arrays.asList(jobTitleArray)));
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -8,8 +8,12 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.application.NameContainsKeywordsPredicate;
+import seedu.address.model.application.*;
+import seedu.address.model.tag.ApplicationStatusTag;
+import seedu.address.model.tag.PriorityTag;
+import seedu.address.model.tag.Tag;
 
 public class FindCommandParserTest {
 
@@ -17,7 +21,8 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -25,13 +30,89 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Grab")));
+        FindCommand expectedFindJobTitleCommand =
+                new FindCommand(new JobTitleContainsKeywordsPredicate(Arrays.asList("SWE")));
+        FindCommand expectedFindTagCommand =
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("overseas")));
+        FindCommand expectedFindPriorityTagCommand =
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("HIGH")));
+        FindCommand expectedFindApplicationStatusTagCommand =
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList("APPLIED")));
+
+        String nameArray[] = new String[] {"Grab", "Shopee" };
+        FindCommand expectedFindCommandWithTwoNamesKeyword =
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameArray)));
+
+        String jobTitleArray[] = new String[] {"Software", "Engineering"};
+        FindCommand expectedFindCommandWithTwoJobTitleKeyword =
+                new FindCommand(new JobTitleContainsKeywordsPredicate(Arrays.asList(jobTitleArray)));
+
+
+        // single field, single parameter
         assertParseSuccess(parser, "find n/Grab", expectedFindCommand);
 
         // multiple parameters for same keywords, last taken
         assertParseSuccess(parser, " find n/Lazada n/Grab", expectedFindCommand);
 
-        // multiple different keywords, first taken
-        assertParseSuccess(parser, " find n/Grab t/overseas", expectedFindCommand);
+        // multiple different keywords, first taken in the sequence of n/ j/ t/ pt/ ast/ (check n/ taken)
+        assertParseSuccess(parser, " find ast/APPLIED pt/HIGH t/overseas j/SWE n/Grab", expectedFindCommand);
+
+        // multiple different keywords, first taken in the sequence of n/ j/ t/ pt/ ast/ (check j/ taken)
+        assertParseSuccess(parser, " find ast/APPLIED pt/HIGH t/overseas j/SWE", expectedFindJobTitleCommand);
+
+        // multiple different keywords, first taken in the sequence of n/ j/ t/ pt/ ast/ (check t/ taken)
+        assertParseSuccess(parser, " find ast/APPLIED pt/HIGH t/overseas", expectedFindTagCommand);
+
+        // multiple different keywords, first taken in the sequence of n/ j/ t/ pt/ ast/ (check pt/ taken)
+        assertParseSuccess(parser, " find ast/APPLIED pt/HIGH", expectedFindPriorityTagCommand);
+
+        // multiple different keywords, first taken in the sequence of n/ j/ t/ pt/ ast/ (check ast/ taken)
+        assertParseSuccess(parser, " find ast/APPLIED", expectedFindApplicationStatusTagCommand);
+
+        // one n/ field, multiple keywords (has spaces)
+        assertParseSuccess(parser, " find n/Grab Shopee", expectedFindCommandWithTwoNamesKeyword);
+
+        // one j/ field, multiple keywords (has spaces)
+        assertParseSuccess(parser, " find j/Software Engineering", expectedFindCommandWithTwoJobTitleKeyword);
     }
 
+    @Test
+    public void parse_invalidValue_failure() {
+    }
+
+    @Test
+    void checkNotEmptyName() {
+        assertParseFailure(parser, "find n/", Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "find n/ ", Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    void checkNotEmptyJobTitle() {
+        assertParseFailure(parser, "find j/", JobTitle.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "find j/ ", JobTitle.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    void checkNotEmptyApplicationStatusTag() {
+        assertParseFailure(parser, "find ast/", ApplicationStatusTag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "find ast/ ", ApplicationStatusTag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "find ast/notapplicationstatustagtype",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_APPLICATION_STATUS_TAG));
+    }
+
+    @Test
+    void checkNotEmptyPriorityTag() {
+        assertParseFailure(parser, "find pt/", PriorityTag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "find pt/ ", PriorityTag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "find pt/notprioritytagtype",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_PRIORITY_TAG));
+
+    }
+
+    @Test
+    void checkNotEmptyTags() {
+        assertParseFailure(parser, "find t/", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "find t/ ", Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "find t/two tags", Tag.MESSAGE_CONSTRAINTS);
+    }
 }


### PR DESCRIPTION
Fixes #172, Fixes #183, Fixes #149 

## Changes made in FindCommandParser.java

- If more than 1 different fields are given, i.e. `find n/shopee j/ML`, only the first field (in the sequence of [n/NAME], [j/JOB_TITLE], [t/TAG]..., [pt/PRIORITY_TAG], [ast/APPLICATION_STATUS_TAG]`) will be processed

- Find command now accepts partial keywords 

- Find command now accepts spaces for n/ and j/



## Other changes made

- Test cases added for find command

- Tag class error message -> "Tag names should be alphanumeric, without spaces and not be empty"; (point out that no spaces allowed)

- PPP added 