### PR TITLE
Fix Interview sorting to include time factor

### DIFF
--- a/src/main/java/seedu/address/logic/sort/InterviewSlotComparator.java
+++ b/src/main/java/seedu/address/logic/sort/InterviewSlotComparator.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.sort;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 
 import seedu.address.model.application.Application;
@@ -14,7 +15,15 @@ public class InterviewSlotComparator implements Comparator<Application> {
      * */
     @Override
     public int compare(Application o1, Application o2) {
-        return o1.getInterviewSlot().getValue().compareTo(o2.getInterviewSlot().getValue());
+        LocalDateTime app1 = o1.getInterviewSlot().getValue();
+        LocalDateTime app2 = o1.getInterviewSlot().getValue();
+        if (app1.isAfter(app2)) {
+            return 1;
+        } else if (app1.isBefore(app2)) {
+            return -1;
+        } else {
+            return o1.getName().toString().compareTo(o2.getName().toString());
+        }
     }
 
     @Override


### PR DESCRIPTION
Comparator for InterviewSlot will now ise `isAfter()` and `isBefore()` instead of default java comparator. 

Fix #176 