### PR TITLE
Bug - sorting by name casing problem

### DIFF
--- a/src/main/java/seedu/address/logic/sort/ApplicationStatusComparator.java
+++ b/src/main/java/seedu/address/logic/sort/ApplicationStatusComparator.java
@@ -1,15 +1,10 @@
 package seedu.address.logic.sort;
 
-import static seedu.address.model.tag.ApplicationStatusTagType.ACCEPTED;
-import static seedu.address.model.tag.ApplicationStatusTagType.APPLIED;
-import static seedu.address.model.tag.ApplicationStatusTagType.INTERVIEWED;
-import static seedu.address.model.tag.ApplicationStatusTagType.NOT_APPLIED;
-import static seedu.address.model.tag.ApplicationStatusTagType.REJECTED;
-
 import java.util.Comparator;
 import java.util.Optional;
 
 import seedu.address.model.application.Application;
+import seedu.address.model.tag.ApplicationStatusTagType;
 import seedu.address.model.tag.Tag;
 
 public class ApplicationStatusComparator implements Comparator<Application> {
@@ -18,31 +13,27 @@ public class ApplicationStatusComparator implements Comparator<Application> {
 
     @Override
     public int compare(Application o1, Application o2) {
-        return getStatusRanking(o1.getApplicationStatusTag()) - getStatusRanking(o2.getApplicationStatusTag());
+        int compareResult = getStatusRanking(o1.getApplicationStatusTag())
+                - getStatusRanking(o2.getApplicationStatusTag());
+        NameComparator nameComparator = new NameComparator();
+        return compareResult == 0
+                ? nameComparator.compare(o1, o2)
+                : -compareResult;
     }
 
     /**
      * Compares the two application's status tag field. Returns a negative integer, zero, or a positive integer as
      * the first argument is less than, equal to, or greater than the second base on alphanumeric order.
-     * The default order from ascending to descend is as follows ACCEPTED, REJECTED, INTERVIEWED, APPLIE and
+     * The default order from ascending to descend is as follows ACCEPTED, REJECTED, INTERVIEWED, APPLIED and
      * NOT_APPLIED.
      * An empty tag will be considered as the lowest ranking, ranked below NOT_APPLIED.
      * */
     private int getStatusRanking(Optional<Tag> t) {
         if (t.isEmpty()) {
-            return 6;
-        } else if (t.get().toString().equals(NOT_APPLIED.toString())) {
-            return 5;
-        } else if (t.get().toString().equals(APPLIED.toString())) {
-            return 4;
-        } else if (t.get().toString().equals(INTERVIEWED.toString())) {
-            return 3;
-        } else if (t.get().toString().equals(REJECTED.toString())) {
-            return 2;
-        } else if (t.get().toString().equals(ACCEPTED.toString())) {
-            return 1;
-        } else {
             return 0;
+        } else {
+            ApplicationStatusTagType applicationStatusTagType = ApplicationStatusTagType.valueOf(t.get().toString());
+            return applicationStatusTagType.getStatusRanking();
         }
     }
 

--- a/src/main/java/seedu/address/logic/sort/InterviewSlotComparator.java
+++ b/src/main/java/seedu/address/logic/sort/InterviewSlotComparator.java
@@ -17,12 +17,13 @@ public class InterviewSlotComparator implements Comparator<Application> {
     public int compare(Application o1, Application o2) {
         LocalDateTime app1 = o1.getInterviewSlot().getValue();
         LocalDateTime app2 = o1.getInterviewSlot().getValue();
+        NameComparator nameComparator = new NameComparator();
         if (app1.isAfter(app2)) {
             return 1;
         } else if (app1.isBefore(app2)) {
             return -1;
         } else {
-            return o1.getName().toString().compareTo(o2.getName().toString());
+            return nameComparator.compare(o1, o2);
         }
     }
 

--- a/src/main/java/seedu/address/logic/sort/NameComparator.java
+++ b/src/main/java/seedu/address/logic/sort/NameComparator.java
@@ -14,7 +14,7 @@ public class NameComparator implements Comparator<Application> {
      * */
     @Override
     public int compare(Application o1, Application o2) {
-        return o1.getName().toString().compareTo(o2.getName().toString());
+        return o1.getName().toString().toUpperCase().compareTo(o2.getName().toString().toUpperCase());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/sort/PriorityComparator.java
+++ b/src/main/java/seedu/address/logic/sort/PriorityComparator.java
@@ -20,8 +20,9 @@ public class PriorityComparator implements Comparator<Application> {
     @Override
     public int compare(Application o1, Application o2) {
         int compareResult = getPriorityRanking(o1.getPriorityTag()) - getPriorityRanking(o2.getPriorityTag());
+        NameComparator nameComparator = new NameComparator();
         return compareResult == 0
-                ? o1.getName().toString().compareTo(o2.getName().toString())
+                ? nameComparator.compare(o1, o2)
                 : compareResult;
     }
 

--- a/src/main/java/seedu/address/model/tag/ApplicationStatusTagType.java
+++ b/src/main/java/seedu/address/model/tag/ApplicationStatusTagType.java
@@ -7,7 +7,14 @@ import java.util.stream.Stream;
  * A public enumeration class for application status tags.
  */
 public enum ApplicationStatusTagType {
-    NOT_APPLIED, APPLIED, INTERVIEWED, REJECTED, ACCEPTED;
+    NOT_APPLIED(0), APPLIED(1), INTERVIEWED(2),
+    REJECTED(3), ACCEPTED(4);
+
+    private final int statusRanking;
+
+    ApplicationStatusTagType(int statusRanking) {
+        this.statusRanking = statusRanking;
+    }
 
     /**
      * Gets all enum values as strings.
@@ -31,5 +38,9 @@ public enum ApplicationStatusTagType {
             }
         }
         return false;
+    }
+
+    public int getStatusRanking() {
+        return this.statusRanking;
     }
 }

--- a/src/main/java/seedu/address/model/tag/PriorityTagType.java
+++ b/src/main/java/seedu/address/model/tag/PriorityTagType.java
@@ -15,10 +15,6 @@ public enum PriorityTagType {
         this.priorityRanking = priorityRanking;
     }
 
-    public int getPriorityRanking() {
-        return this.priorityRanking;
-    }
-
     /**
      * Gets all enum values as strings.
      * @return All enum values as a concatenated string.
@@ -41,5 +37,9 @@ public enum PriorityTagType {
             }
         }
         return false;
+    }
+
+    public int getPriorityRanking() {
+        return this.priorityRanking;
     }
 }


### PR DESCRIPTION
Sorting previously separated lowercase and uppercase sorting for the `name` field.

Have defaulted all values to upper case when sorting to ignore casing when sorting by `name`.

Fix #178 